### PR TITLE
fixed bug for old version of (your) pyhal interface...

### DIFF
--- a/pygce/models/bot.py
+++ b/pygce/models/bot.py
@@ -7,7 +7,7 @@ import json
 from datetime import timedelta
 
 from bs4 import BeautifulSoup
-from hal.internet.selenium_bots import SeleniumForm
+from hal.internet.selenium import SeleniumFormFiller
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -117,7 +117,7 @@ class GarminConnectBot(object):
 
         try:
             self._go_to(self.login_url)  # open login url
-            SeleniumForm(self.browser).fill_login_form(
+            SeleniumFormFiller(self.browser).fill_login_form(
                 self.user_name, self.USERNAME_FIELD_NAME,
                 self.user_password, self.PASSWORD_FIELD_NAME
             )  # fill login form


### PR DESCRIPTION
Fixes #

**command**

pygce -h

**produce error**

ModuleNotFoundError: No module named 'hal.internet.selenium_bots'

_because you changed your interface for `selenium_bots` `SeleniumForm`  in `SeleniumFormFiller`_

## Proposed Changes

  - `selenium_bots` and `SeleniumForm` --> `selenium_bots` and `SeleniumFormFiller`